### PR TITLE
Add support for atomic operations on access types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         gnat_version: [^10, ^11, ^12]
+        exclude:
+          - os: ubuntu-latest
+            gnat_version: ^10
+          - os: ubuntu-latest
+            gnat_version: ^11
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,17 +10,29 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        gnat_version: [^10, ^11, ^12]
+        gnat_version: [^10, ^11, ^12, ^13, ^14, ^15]
         exclude:
+          # GNAT versions 10 and 11 don't work on ubuntu-latest as they don't
+          # understand the more recent RELR sections in the system libc
           - os: ubuntu-latest
             gnat_version: ^10
           - os: ubuntu-latest
             gnat_version: ^11
+          # GNAT native builds for aarch64 macos were introduced since GNAT FSF 13
+          - os: macos-latest
+            gnat_version: ^10
+          - os: macos-latest
+            gnat_version: ^11
+          - os: macos-latest
+            gnat_version: ^12
+          - os: macos-latest
+            gnat_version: ^13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: alire-project/setup-alire@v1
+      - uses: alire-project/setup-alire@v4
         with:
+          version: 2.1.0
           toolchain: gnat_native${{ matrix.gnat_version }} gprbuild --disable-assistant
       - run: alr build
       - run: cd tests && alr build --validation
@@ -28,13 +40,13 @@ jobs:
 
         # Produce an Alire release manifest
       - name: Make Release Manifest
-        if: (startsWith(matrix.os, 'ubuntu'))
+        if: (github.event_name == 'release' && startsWith(matrix.os, 'ubuntu'))
         run: |
           # Set user GitHub login required for `alr publish`
           alr config --set --global user.github_login ${{github.repository_owner}}
 
           # Run Alire publish assistant
-          alr publish ${{github.server_url}}/${{github.repository}} ${{github.sha}}
+          alr publish ${{github.server_url}}/${{github.repository}} ${{github.sha}} --skip-submit
 
         # Save the path to the release manifest for the next step.
         # This is a little trick to get around the fact that the actions/upload-release-asset doesn't allow globing pattern.
@@ -62,20 +74,31 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        gnat_version: [^10, ^11, ^12]
+        gnat_version: [^10, ^11, ^12, ^13, ^14, ^15]
+        exclude:
+          # GNAT arm_elf builds for aarch64 macos were introduced since GNAT FSF 14
+          - os: macos-latest
+            gnat_version: ^10
+          - os: macos-latest
+            gnat_version: ^11
+          - os: macos-latest
+            gnat_version: ^12
+          - os: macos-latest
+            gnat_version: ^13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: alire-project/setup-alire@v1
+      - uses: alire-project/setup-alire@v4
         with:
+          version: 2.1.0
           toolchain: gnat_arm_elf${{ matrix.gnat_version }} gprbuild --disable-assistant
 
       - run: cd tests/armv6m && alr build --validation
-        if: ${{ matrix.gnat_version == '^12' }}
+        if: ${{ !startsWith(matrix.gnat_version, '^10') && !startsWith(matrix.gnat_version, '^11') }}
       - run: cd tests/rp2040_spinlock && alr build --validation
-        if: ${{ matrix.gnat_version == '^12' }}
+        if: ${{ !startsWith(matrix.gnat_version, '^10') && !startsWith(matrix.gnat_version, '^11') }}
 
       - run: cd tests/armv6m && alr build --validation -- -XTESTS_RUNTIME=zfp-cortex-m0
-        if: ${{ matrix.gnat_version != '^12' }}
+        if: ${{ startsWith(matrix.gnat_version, '^10') || startsWith(matrix.gnat_version, '^11') }}
       - run: cd tests/rp2040_spinlock && alr build --validation  -- -XTESTS_RUNTIME=zfp-cortex-m0
-        if: ${{ matrix.gnat_version != '^12' }}
+        if: ${{ startsWith(matrix.gnat_version, '^10') || startsWith(matrix.gnat_version, '^11') }}

--- a/src/atomic-basic_operations.ads
+++ b/src/atomic-basic_operations.ads
@@ -1,0 +1,113 @@
+generic
+   type T is private;
+package Atomic.Basic_Operations with Preelaborate, SPARK_Mode => On is
+   --  Based on GCC atomic built-ins. See:
+   --  https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
+   --
+   --  The specification is exactly the same for all sizes of data (8, 16, 32,
+   --  64).
+
+   pragma
+     Compile_Time_Error
+       (T'Object_Size not in 8 | 16 | 32 | 64,
+        "Atomic builtins not available for objects of this size");
+
+   type Instance is limited private;
+   --  This type is limited and private, it can only be manipulated using the
+   --  primitives below.
+
+   function Init (Val : T) return Instance
+   with Post => Value (Init'Result) = Val;
+   --  Can be used to initialize an atomic instance:
+   --
+   --  A : My_Atomic_Access.Instance := My_Atomic_Access.Init (null);
+
+   function Value (This : Instance) return T
+   with Ghost;
+   --  Ghost function to get the value of an instance without needing it
+   --  aliased. This function can be used in contracts for instance.
+   --  This doesn't use the atomic built-ins.
+
+   function Load
+     (This : aliased Instance; Order : Mem_Order := Seq_Cst) return T
+   with
+     Pre  => Order in Relaxed | Consume | Acquire | Seq_Cst,
+     Post => Load'Result = Value (This);
+
+   procedure Store
+     (This : aliased in out Instance; Val : T; Order : Mem_Order := Seq_Cst)
+   with
+     Pre  => Order in Relaxed | Release | Seq_Cst,
+     Post => Value (This) = Val;
+
+   procedure Exchange
+     (This  : aliased in out Instance;
+      Val   : T;
+      Old   : out T;
+      Order : Mem_Order := Seq_Cst)
+   with
+     Pre  => Order in Relaxed | Acquire | Release | Acq_Rel | Seq_Cst,
+     Post => Old = Value (This)'Old and then Value (This) = Val;
+
+   procedure Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success       : out Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst)
+   with
+     Pre  =>
+       Failure_Order in Relaxed | Consume | Acquire | Seq_Cst
+       and then not Stronger (Failure_Order, Success_Order),
+     Post =>
+       Success = (Value (This)'Old = Expected)
+       and then (if Success then Value (This) = Desired);
+
+   function Exchange
+     (This : aliased in out Instance; Val : T; Order : Mem_Order := Seq_Cst)
+      return T
+   with
+     SPARK_Mode => Off,
+     Post       =>
+       Exchange'Result = Value (This)'Old and then Value (This) = Val;
+
+   function Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst) return Boolean
+   with
+     SPARK_Mode => Off,
+     Post       =>
+       Compare_Exchange'Result = (Value (This)'Old = Expected)
+       and then (if Compare_Exchange'Result then Value (This) = Desired);
+
+private
+
+   type Instance is new T;
+
+   ----------
+   -- Init --
+   ----------
+
+   function Init (Val : T) return Instance
+   is (Instance (Val));
+
+   -----------
+   -- Value --
+   -----------
+
+   function Value (This : Instance) return T
+   is (T (This));
+
+   pragma Inline (Init);
+   pragma Inline (Load);
+   pragma Inline (Store);
+   pragma Inline (Exchange);
+   pragma Inline (Compare_Exchange);
+
+end Atomic.Basic_Operations;

--- a/src/critical_section/atomic-basic_operations.adb
+++ b/src/critical_section/atomic-basic_operations.adb
@@ -1,0 +1,122 @@
+with Atomic.Critical_Section; use Atomic.Critical_Section;
+
+with System;
+
+package body Atomic.Basic_Operations
+  with SPARK_Mode => Off
+is
+
+   ----------
+   -- Load --
+   ----------
+
+   function Load
+     (This : aliased Instance; Order : Mem_Order := Seq_Cst) return T
+   is
+      Vola   : T with Volatile, Import, Address => This'Address;
+      State  : Interrupt_State;
+      Result : T;
+   begin
+      Critical_Section.Enter (State);
+      Result := Vola;
+      Critical_Section.Leave (State);
+      return Result;
+   end Load;
+
+   -----------
+   -- Store --
+   -----------
+
+   procedure Store
+     (This  : aliased in out Instance;
+      Val   : T;
+      Order : Mem_Order := Seq_Cst)
+   is
+      Vola  : T with Volatile, Import, Address => This'Address;
+      State : Interrupt_State;
+   begin
+      Critical_Section.Enter (State);
+      Vola := Val;
+      Critical_Section.Leave (State);
+   end Store;
+
+   --------------
+   -- Exchange --
+   --------------
+
+   procedure Exchange
+     (This  : aliased in out Instance;
+      Val   : T;
+      Old   : out T;
+      Order : Mem_Order := Seq_Cst)
+   is
+      Vola  : T with Volatile, Import, Address => This'Address;
+      State : Interrupt_State;
+   begin
+      Critical_Section.Enter (State);
+      Old := Vola;
+      Vola := Val;
+      Critical_Section.Leave (State);
+   end Exchange;
+
+   ----------------------
+   -- Compare_Exchange --
+   ----------------------
+
+   procedure Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success       : out Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst)
+   is
+      Vola  : T with Volatile, Import, Address => This'Address;
+      State : Interrupt_State;
+   begin
+      Critical_Section.Enter (State);
+      if Vola = Expected then
+         Vola := Desired;
+         Success := True;
+      else
+         Success := False;
+      end if;
+      Critical_Section.Leave (State);
+   end Compare_Exchange;
+
+   --------------
+   -- Exchange --
+   --------------
+
+   function Exchange
+     (This  : aliased in out Instance;
+      Val   : T;
+      Order : Mem_Order := Seq_Cst) return T
+   is
+      Result : T;
+   begin
+      Exchange (This, Val, Result, Order);
+      return Result;
+   end Exchange;
+
+   ----------------------
+   -- Compare_Exchange --
+   ----------------------
+
+   function Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst) return Boolean
+   is
+      Result : Boolean;
+   begin
+      Compare_Exchange (This, Expected, Desired, Weak, Result, Success_Order,
+                        Failure_Order);
+      return Result;
+   end Compare_Exchange;
+
+end Atomic.Basic_Operations;

--- a/src/intrinsic/atomic-basic_operations.adb
+++ b/src/intrinsic/atomic-basic_operations.adb
@@ -1,0 +1,387 @@
+with System;
+
+package body Atomic.Basic_Operations
+  with SPARK_Mode => Off
+is
+
+   ----------
+   -- Load --
+   ----------
+
+   function Load
+     (This : aliased Instance; Order : Mem_Order := Seq_Cst) return T
+   is
+      pragma Warnings (Off);
+
+      function Intrinsic8
+        (Ptr : System.Address; Model : Integer) return T;
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_load_1");
+
+      function Intrinsic16
+        (Ptr : System.Address; Model : Integer) return T;
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_load_2");
+
+      function Intrinsic32
+        (Ptr : System.Address; Model : Integer) return T;
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_load_4");
+
+      function Intrinsic64
+        (Ptr : System.Address; Model : Integer) return T;
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_load_8");
+
+      pragma Warnings (On);
+   begin
+      case T'Object_Size is
+         when 8      =>
+            return Intrinsic8 (This'Address, Order'Enum_Rep);
+
+         when 16     =>
+            return Intrinsic16 (This'Address, Order'Enum_Rep);
+
+         when 32     =>
+            return Intrinsic32 (This'Address, Order'Enum_Rep);
+
+         when 64     =>
+            return Intrinsic64 (This'Address, Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Load;
+
+   -----------
+   -- Store --
+   -----------
+
+   procedure Store
+     (This  : aliased in out Instance;
+      Val   : T;
+      Order : Mem_Order := Seq_Cst)
+   is
+      pragma Warnings (Off);
+
+      procedure Intrinsic8
+        (Ptr : System.Address; Val : T; Model : Integer);
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_store_1");
+
+      procedure Intrinsic16
+        (Ptr : System.Address; Val : T; Model : Integer);
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_store_2");
+
+      procedure Intrinsic32
+        (Ptr : System.Address; Val : T; Model : Integer);
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_store_4");
+
+      procedure Intrinsic64
+        (Ptr : System.Address; Val : T; Model : Integer);
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_store_8");
+
+      pragma Warnings (On);
+   begin
+      case T'Object_Size is
+         when 8      =>
+            Intrinsic8 (This'Address, Val, Order'Enum_Rep);
+
+         when 16     =>
+            Intrinsic16 (This'Address, Val, Order'Enum_Rep);
+
+         when 32     =>
+            Intrinsic32 (This'Address, Val, Order'Enum_Rep);
+
+         when 64     =>
+            Intrinsic64 (This'Address, Val, Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Store;
+
+   --------------
+   -- Exchange --
+   --------------
+
+   procedure Exchange
+     (This  : aliased in out Instance;
+      Val   : T;
+      Old   : out T;
+      Order : Mem_Order := Seq_Cst)
+   is
+      pragma Warnings (Off);
+
+      function Intrinsic8
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_exchange_1");
+
+      function Intrinsic16
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_exchange_2");
+
+      function Intrinsic32
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_exchange_4");
+
+      function Intrinsic64
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_exchange_8");
+
+      pragma Warnings (On);
+   begin
+      case T'Object_Size is
+         when 8      =>
+            Old := Intrinsic8 (This'Address, Val, Order'Enum_Rep);
+
+         when 16     =>
+            Old := Intrinsic16 (This'Address, Val, Order'Enum_Rep);
+
+         when 32     =>
+            Old := Intrinsic32 (This'Address, Val, Order'Enum_Rep);
+
+         when 64     =>
+            Old := Intrinsic64 (This'Address, Val, Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Exchange;
+
+   ----------------------
+   -- Compare_Exchange --
+   ----------------------
+
+   procedure Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success       : out Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst)
+   is
+      pragma Warnings (Off);
+
+      function Intrinsic8
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_compare_exchange_1");
+
+      function Intrinsic16
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_compare_exchange_2");
+
+      function Intrinsic32
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_compare_exchange_4");
+
+      function Intrinsic64
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_compare_exchange_8");
+
+      pragma Warnings (On);
+
+      Exp : T := Expected;
+   begin
+      case T'Object_Size is
+         when 8      =>
+            Success :=
+              Intrinsic8
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 16     =>
+            Success :=
+              Intrinsic16
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 32     =>
+            Success :=
+              Intrinsic32
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 64     =>
+            Success :=
+              Intrinsic64
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Compare_Exchange;
+
+   --------------
+   -- Exchange --
+   --------------
+
+   function Exchange
+     (This  : aliased in out Instance;
+      Val   : T;
+      Order : Mem_Order := Seq_Cst) return T
+   is
+      pragma Warnings (Off);
+
+      function Intrinsic8
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_exchange_1");
+
+      function Intrinsic16
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_exchange_2");
+
+      function Intrinsic32
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_exchange_4");
+
+      function Intrinsic64
+        (Ptr : System.Address; Val : T; Model : Integer)
+         return T;
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_exchange_8");
+
+      pragma Warnings (On);
+   begin
+      case T'Object_Size is
+         when 8      =>
+            return Intrinsic8 (This'Address, Val, Order'Enum_Rep);
+
+         when 16     =>
+            return Intrinsic16 (This'Address, Val, Order'Enum_Rep);
+
+         when 32     =>
+            return Intrinsic32 (This'Address, Val, Order'Enum_Rep);
+
+         when 64     =>
+            return Intrinsic64 (This'Address, Val, Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Exchange;
+
+   ----------------------
+   -- Compare_Exchange --
+   ----------------------
+
+   function Compare_Exchange
+     (This          : aliased in out Instance;
+      Expected      : T;
+      Desired       : T;
+      Weak          : Boolean;
+      Success_Order : Mem_Order := Seq_Cst;
+      Failure_Order : Mem_Order := Seq_Cst) return Boolean
+   is
+      pragma Warnings (Off);
+
+      function Intrinsic8
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic8, "__atomic_compare_exchange_1");
+
+      function Intrinsic16
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic16, "__atomic_compare_exchange_2");
+
+      function Intrinsic32
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic32, "__atomic_compare_exchange_4");
+
+      function Intrinsic64
+        (Ptr, Expected                : System.Address;
+         Desired                      : T;
+         Weak                         : Boolean;
+         Success_Order, Failure_Order : Integer) return Boolean;
+      pragma Import (Intrinsic, Intrinsic64, "__atomic_compare_exchange_8");
+
+      pragma Warnings (On);
+
+      Exp : T := Expected;
+   begin
+      case T'Object_Size is
+         when 8      =>
+            return
+              Intrinsic8
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 16     =>
+            return
+              Intrinsic16
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 32     =>
+            return
+              Intrinsic32
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when 64     =>
+            return
+              Intrinsic64
+                (This'Address,
+                 Exp'Address,
+                 Desired,
+                 Weak,
+                 Success_Order'Enum_Rep,
+                 Failure_Order'Enum_Rep);
+
+         when others =>
+            raise Program_Error;
+      end case;
+   end Compare_Exchange;
+
+end Atomic.Basic_Operations;

--- a/tests/armv6m/ld/memmap_default.ld
+++ b/tests/armv6m/ld/memmap_default.ld
@@ -1,0 +1,174 @@
+/****************************************************************************
+ *                                                                          *
+ *                         GNAT COMPILER COMPONENTS                         *
+ *                                                                          *
+ *                                  A R M                                   *
+ *                                                                          *
+ *                            Linker Script File                            *
+ *                                                                          *
+ *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
+ *             Copyright (C) 2003-2006 The European Space Agency            *
+ *                   Copyright (C) 2003-2021 AdaCore                        *
+ *                                                                          *
+ * GNAT is free software;  you can  redistribute it  and/or modify it under *
+ * terms of the  GNU General Public License as published  by the Free Soft- *
+ * ware  Foundation;  either version 2,  or (at your option) any later ver- *
+ * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
+ * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
+ * for  more details.  You should have  received  a copy of the GNU General *
+ * Public License  distributed with GNAT;  see file COPYING.  If not, write *
+ * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
+ * Boston, MA 02110-1301, USA.                                              *
+ *                                                                          *
+ * As a  special  exception,  if you  link  this file  with other  files to *
+ * produce an executable,  this file does not by itself cause the resulting *
+ * executable to be covered by the GNU General Public License. This except- *
+ * ion does not  however invalidate  any other reasons  why the  executable *
+ * file might be covered by the  GNU Public License.                        *
+ *                                                                          *
+ * GNARL was developed by the GNARL team at Florida State University.       *
+ * Extensive contributions were provided by Ada Core Technologies, Inc.     *
+ * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
+ * Technical University of Madrid.                                          *
+ *                                                                          *
+ ****************************************************************************/
+
+/* This is a ARM specific version of this file */
+
+MEMORY
+{
+  flash  (rx) : ORIGIN = 0x10000000, LENGTH = 2M
+  sram  (rwx) : ORIGIN = 0x20000000, LENGTH = 256k
+}
+
+REGION_ALIAS("sram_tx", sram)
+REGION_ALIAS("sram_ro", sram)
+REGION_ALIAS("sram_bs", sram)
+REGION_ALIAS("sram_da", sram)
+
+/* This script replaces ld's default linker script, providing the
+   appropriate memory map and output format. */
+
+_DEFAULT_STACK_SIZE = 2*1024;
+
+ENTRY(_start_rom);
+
+SECTIONS
+{
+
+  .boot2 : {
+      __boot2_start__ = .;
+      KEEP (*(.boot2))
+      __boot2_end__ = .;
+  } > flash
+
+  .text :
+  {
+    KEEP (*(.vectors))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+
+    /* Exclude all time-critical code from flash (e.g. floating point, memcpy, memset, etc) */
+    *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *libgnat.a:s-mem*.o) .text*)
+  } > flash
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > flash
+  /* .ARM.exidx is 4-bytes aligned, so __exidx_start needs to be
+     aligned too. Note that assigning the location counter also makes
+     ld attach the following symbols to the next section (instead of the
+     previous section which is the default), so will properly
+     consider the location counter of .ARM.exidx for __exidx_start and
+      __exidx_end and not the previous section's one. */
+  . = ALIGN(0x4);
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } > flash
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  .rodata :
+  {
+    *(.lit)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+
+    /* Exclude all time-critical data from flash (e.g. RO data for floating point, memcpy, memset, etc) */
+    *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *libgnat.a:s-mem*.o) .rodata*)
+    . = ALIGN(0x4);
+    __rom_end = .;
+  } > flash
+
+  __data_load = __rom_end;
+  .data : AT (__data_load)
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+
+    /* Ensure that the end of the data section is always word aligned.
+       Initial values are stored in 4-bytes blocks so we must guarantee
+       that these blocks do not fall out the section (otherwise they are
+       truncated and the initial data for the last block are lost). */
+
+    . = ALIGN(0x4);
+    __data_end = .;
+  } > sram_da
+  __data_words = (__data_end - __data_start) >> 2;
+
+  .bss (NOLOAD): {
+   . = ALIGN(0x8);
+   __bss_start = .;
+
+   *(.bss .bss.*)
+   *(COMMON)
+
+   . = ALIGN(0x8);    /* Align the stack to 64 bits */
+   __bss_end = .;
+
+   __interrupt_stack_start = .;
+   *(.noinit.interrupt_stacks)
+   . = ALIGN(0x8);
+   __interrupt_stack_end = .;
+
+   /* Stack for core0 */
+   __stack_start = .;
+   . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+   . = ALIGN(0x8);
+   __stack_end = .;
+
+   /* Stack for core1 */
+   __stack_start_core1 = .;
+   *(.stack1)
+   . = ALIGN(0x8);
+   __stack_end_core1 = .;
+
+   _end = .;
+   __heap_start = .;
+   __heap_end = ORIGIN(sram_bs) + LENGTH(sram_bs);
+  } > sram_bs
+
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/tests/armv6m/tests.gpr
+++ b/tests/armv6m/tests.gpr
@@ -18,4 +18,8 @@ project Tests is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
 
+   package Linker is
+      for Switches ("Ada") use ("-Lld", "-Tmemmap_default.ld");
+   end Linker;
+
 end Tests;

--- a/tests/rp2040_spinlock/ld/memmap_default.ld
+++ b/tests/rp2040_spinlock/ld/memmap_default.ld
@@ -1,0 +1,174 @@
+/****************************************************************************
+ *                                                                          *
+ *                         GNAT COMPILER COMPONENTS                         *
+ *                                                                          *
+ *                                  A R M                                   *
+ *                                                                          *
+ *                            Linker Script File                            *
+ *                                                                          *
+ *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
+ *             Copyright (C) 2003-2006 The European Space Agency            *
+ *                   Copyright (C) 2003-2021 AdaCore                        *
+ *                                                                          *
+ * GNAT is free software;  you can  redistribute it  and/or modify it under *
+ * terms of the  GNU General Public License as published  by the Free Soft- *
+ * ware  Foundation;  either version 2,  or (at your option) any later ver- *
+ * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
+ * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
+ * for  more details.  You should have  received  a copy of the GNU General *
+ * Public License  distributed with GNAT;  see file COPYING.  If not, write *
+ * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
+ * Boston, MA 02110-1301, USA.                                              *
+ *                                                                          *
+ * As a  special  exception,  if you  link  this file  with other  files to *
+ * produce an executable,  this file does not by itself cause the resulting *
+ * executable to be covered by the GNU General Public License. This except- *
+ * ion does not  however invalidate  any other reasons  why the  executable *
+ * file might be covered by the  GNU Public License.                        *
+ *                                                                          *
+ * GNARL was developed by the GNARL team at Florida State University.       *
+ * Extensive contributions were provided by Ada Core Technologies, Inc.     *
+ * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
+ * Technical University of Madrid.                                          *
+ *                                                                          *
+ ****************************************************************************/
+
+/* This is a ARM specific version of this file */
+
+MEMORY
+{
+  flash  (rx) : ORIGIN = 0x10000000, LENGTH = 2M
+  sram  (rwx) : ORIGIN = 0x20000000, LENGTH = 256k
+}
+
+REGION_ALIAS("sram_tx", sram)
+REGION_ALIAS("sram_ro", sram)
+REGION_ALIAS("sram_bs", sram)
+REGION_ALIAS("sram_da", sram)
+
+/* This script replaces ld's default linker script, providing the
+   appropriate memory map and output format. */
+
+_DEFAULT_STACK_SIZE = 2*1024;
+
+ENTRY(_start_rom);
+
+SECTIONS
+{
+
+  .boot2 : {
+      __boot2_start__ = .;
+      KEEP (*(.boot2))
+      __boot2_end__ = .;
+  } > flash
+
+  .text :
+  {
+    KEEP (*(.vectors))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+
+    /* Exclude all time-critical code from flash (e.g. floating point, memcpy, memset, etc) */
+    *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *libgnat.a:s-mem*.o) .text*)
+  } > flash
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > flash
+  /* .ARM.exidx is 4-bytes aligned, so __exidx_start needs to be
+     aligned too. Note that assigning the location counter also makes
+     ld attach the following symbols to the next section (instead of the
+     previous section which is the default), so will properly
+     consider the location counter of .ARM.exidx for __exidx_start and
+      __exidx_end and not the previous section's one. */
+  . = ALIGN(0x4);
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } > flash
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  .rodata :
+  {
+    *(.lit)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+
+    /* Exclude all time-critical data from flash (e.g. RO data for floating point, memcpy, memset, etc) */
+    *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *libgnat.a:s-mem*.o) .rodata*)
+    . = ALIGN(0x4);
+    __rom_end = .;
+  } > flash
+
+  __data_load = __rom_end;
+  .data : AT (__data_load)
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+
+    /* Ensure that the end of the data section is always word aligned.
+       Initial values are stored in 4-bytes blocks so we must guarantee
+       that these blocks do not fall out the section (otherwise they are
+       truncated and the initial data for the last block are lost). */
+
+    . = ALIGN(0x4);
+    __data_end = .;
+  } > sram_da
+  __data_words = (__data_end - __data_start) >> 2;
+
+  .bss (NOLOAD): {
+   . = ALIGN(0x8);
+   __bss_start = .;
+
+   *(.bss .bss.*)
+   *(COMMON)
+
+   . = ALIGN(0x8);    /* Align the stack to 64 bits */
+   __bss_end = .;
+
+   __interrupt_stack_start = .;
+   *(.noinit.interrupt_stacks)
+   . = ALIGN(0x8);
+   __interrupt_stack_end = .;
+
+   /* Stack for core0 */
+   __stack_start = .;
+   . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+   . = ALIGN(0x8);
+   __stack_end = .;
+
+   /* Stack for core1 */
+   __stack_start_core1 = .;
+   *(.stack1)
+   . = ALIGN(0x8);
+   __stack_end_core1 = .;
+
+   _end = .;
+   __heap_start = .;
+   __heap_end = ORIGIN(sram_bs) + LENGTH(sram_bs);
+  } > sram_bs
+
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/tests/rp2040_spinlock/tests.gpr
+++ b/tests/rp2040_spinlock/tests.gpr
@@ -18,4 +18,8 @@ project Tests is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
 
+   package Linker is
+      for Switches ("Ada") use ("-Lld", "-Tmemmap_default.ld");
+   end Linker;
+
 end Tests;

--- a/tests/src/main.adb
+++ b/tests/src/main.adb
@@ -3,6 +3,7 @@ pragma Assertion_Policy (Check);
 with Atomic;
 with Atomic.Unsigned;
 with Atomic.Signed;
+with Atomic.Basic_Operations;
 with Ada.Text_IO;
 with Interfaces;
 
@@ -15,6 +16,14 @@ procedure Main is
    generic
       type T is range <>;
    procedure Test_Signed;
+
+   generic
+      type T is range <>;
+   procedure Test_General_Access;
+
+   generic
+      type T is range <>;
+   procedure Test_Pool_Specific_Access;
 
    -------------------
    -- Test_Unsigned --
@@ -316,6 +325,115 @@ procedure Main is
       Ada.Text_IO.Put_Line ("SUCCESS Signed" & T'Object_Size'Img);
    end Test_Signed;
 
+   -------------------------
+   -- Test_General_Access --
+   -------------------------
+
+   procedure Test_General_Access is
+      type T_Access is access all T;
+
+      package GA_Atomic is new Atomic.Basic_Operations (T_Access);
+      use GA_Atomic;
+
+      Obj_1 : aliased T := T'First;
+      Obj_2 : aliased T := T'Last;
+
+      V : aliased Instance := Init (Obj_1'Access);
+      Old : T_Access := Obj_1'Access;
+      Success : Boolean;
+   begin
+
+      pragma Assert (Load (V) = Obj_1'Access);
+      Store (V, Obj_2'Access);
+      pragma Assert (Load (V) = Obj_2'Access);
+
+      Exchange (V, Obj_1'Access, Old);
+      pragma Assert (Load (V) = Obj_1'Access);
+      pragma Assert (Old = Obj_2'Access);
+
+      Compare_Exchange (V,
+                        Expected      => Obj_2'Access,
+                        Desired       => Obj_1'Access,
+                        Weak          => True,
+                        Success       => Success);
+      pragma Assert (not Success);
+
+      Compare_Exchange (V,
+                        Expected      => Obj_1'Access,
+                        Desired       => Obj_2'Access,
+                        Weak          => True,
+                        Success       => Success);
+      pragma Assert (Success);
+      pragma Assert (Load (V) = Obj_2'Access);
+
+      Store (V, Obj_2'Access);
+      pragma Assert (Exchange (V, Obj_1'Access) = Obj_2'Access);
+      pragma Assert (Load (V) = Obj_1'Access);
+
+      Store (V, Obj_2'Access);
+      pragma Assert (not Compare_Exchange (V, Obj_1'Access, Obj_1'Access,
+                                           Weak => True));
+      pragma Assert (Compare_Exchange (V, Obj_2'Access, Obj_1'Access,
+                                       Weak => True));
+      pragma Assert (Load (V) = Obj_1'Access);
+
+      Ada.Text_IO.Put_Line ("SUCCESS General_Access");
+   end Test_General_Access;
+
+   -------------------------------
+   -- Test_Pool_Specific_Access --
+   -------------------------------
+
+   procedure Test_Pool_Specific_Access is
+      type T_Access is access T;
+
+      package PSA_Atomic is new Atomic.Basic_Operations (T_Access);
+      use PSA_Atomic;
+
+      Ptr_1 : constant T_Access := new T'(T'First);
+      Ptr_2 : constant T_Access := new T'(T'Last);
+
+      V : aliased Instance := Init (Ptr_1);
+      Old : T_Access := Ptr_1;
+      Success : Boolean;
+   begin
+
+      pragma Assert (Load (V) = Ptr_1);
+      Store (V, Ptr_2);
+      pragma Assert (Load (V) = Ptr_2);
+
+      Exchange (V, Ptr_1, Old);
+      pragma Assert (Load (V) = Ptr_1);
+      pragma Assert (Old = Ptr_2);
+
+      Compare_Exchange (V,
+                        Expected      => Ptr_2,
+                        Desired       => Ptr_1,
+                        Weak          => True,
+                        Success       => Success);
+      pragma Assert (not Success);
+
+      Compare_Exchange (V,
+                        Expected      => Ptr_1,
+                        Desired       => Ptr_2,
+                        Weak          => True,
+                        Success       => Success);
+      pragma Assert (Success);
+      pragma Assert (Load (V) = Ptr_2);
+
+      Store (V, Ptr_2);
+      pragma Assert (Exchange (V, Ptr_1) = Ptr_2);
+      pragma Assert (Load (V) = Ptr_1);
+
+      Store (V, Ptr_2);
+      pragma Assert (not Compare_Exchange (V, Ptr_1, Ptr_1,
+                                           Weak => True));
+      pragma Assert (Compare_Exchange (V, Ptr_2, Ptr_1, Weak => True));
+      pragma Assert (Load (V) = Ptr_1);
+
+      Ada.Text_IO.Put_Line ("SUCCESS Pool_Specific_Access");
+   end Test_Pool_Specific_Access;
+
    procedure Test_U8 is new Test_Unsigned (Interfaces.Unsigned_8);
    procedure Test_U16 is new Test_Unsigned (Interfaces.Unsigned_16);
    procedure Test_U32 is new Test_Unsigned (Interfaces.Unsigned_32);
@@ -325,6 +443,9 @@ procedure Main is
    procedure Test_S16 is new Test_Signed (Interfaces.Integer_16);
    procedure Test_S32 is new Test_Signed (Interfaces.Integer_32);
    procedure Test_S64 is new Test_Signed (Interfaces.Integer_64);
+
+   procedure Test_General_Ptr is new Test_General_Access (Integer);
+   procedure Test_Pool_Specific_Ptr is new Test_Pool_Specific_Access (Integer);
 
 begin
 
@@ -337,5 +458,8 @@ begin
    Test_S16;
    Test_S32;
    Test_S64;
+
+   Test_General_Ptr;
+   Test_Pool_Specific_Ptr;
 
 end Main;


### PR DESCRIPTION
So I found myself needing to exchange pointers atomically for a project of mine but it turns out that `System.Atomic_Operations.Exchange` is not available in embedded runtimes, so I think it would be nice to add atomic pointer support to this crate and thought I'd have a go at adding it.

I've added support for four atomic operations on pointers:
* Load
* Store
* Exchange
* Compare_Exchange

Both pool-specific (`access`) and general (`access all`) access types are supported.

Note that both these new packages have `SPARK_Mode => Off` since they are not compatible with SPARK's ownership rules, but I thought to keep the contracts anyway for consistency.

I've also added tests for these new packages.

What do you think?
